### PR TITLE
Fix: Profile avatar not visible across all pages after uploading a profile picture

### DIFF
--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -124,8 +124,8 @@ class MediaController extends Controller
 
                         UserMeta::updateOrCreate(
                             ['ref_parent' => Auth::user()->id,'meta_key'   => 'profile_picture_path'],
-                            ['meta_value' => "storage/media/",'status'     => 'active']
-                        );
+                            ['meta_value' => asset("storage/media") . "/", 'status' => 'active']
+                         );
                 Log::info("medias=" . $medias);
 
                 if (isset($medias)) {


### PR DESCRIPTION
After uploading a profile picture, the avatar in the top right navbar was not visible on certain pages like inbox, channels etc.
Root Cause:
In MediaController.php, the profile_picture_path was being stored as a relative path storage/media/ in the database. This caused the browser to resolve the image URL relative to the current page instead of the app root, resulting in a broken image on deeper routes.
Fix:
Wrapped the stored path with asset() and added a trailing slash to ensure an absolute URL is always stored.